### PR TITLE
PLTCONN-1789: Publish to NPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Publish to NPM
         run: npm publish --access public
         env:
-          GITHUB_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: ./package.json
+          access: public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm ci && npm test
 
       - name: Publish to NPM
-        run: npm publish
+        run: npm publish --access public
         env:
           GITHUB_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
-name: PRB
+name: Release
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - '*'
   pull_request:
     branches: [ main ]
 
 jobs:
-  node-build:
+  release:
     runs-on: ubuntu-latest
 
     strategy:
@@ -25,3 +26,8 @@ jobs:
 
       - name: Run tests
         run: npm ci && npm test
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         run: npm ci && npm test
 
       - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
-    branches: [ main ]
 
 jobs:
   release:
@@ -26,6 +24,9 @@ jobs:
 
       - name: Run tests
         run: npm ci && npm test
+
+      - name: Set package version
+        run: npm version ${{  github.ref_name }} --no-git-tag-version
 
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"name": "@sailpoint/connector-sdk",
 			"version": "0.1.0",
-			"license": "Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved.",
+			"license": "Copyright (c) 2023. SailPoint Technologies, Inc. All rights reserved.",
 			"dependencies": {
 				"archiver": "^5.3.1",
 				"express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@sailpoint/connector-sdk",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"description": "JavaScript framework to build SailPoint Connectors",
 	"author": "SailPoint Technologies, Inc.",
-	"license": "Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved.",
+	"license": "Copyright (c) 2023. SailPoint Technologies, Inc. All rights reserved.",
 	"keywords": [
 		"sailpoint",
 		"connector"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@sailpoint/connector-sdk",
 	"private": true,
-	"version": "0.1.0",
+	"version": "0.0.1",
 	"description": "JavaScript framework to build SailPoint Connectors",
 	"author": "SailPoint Technologies, Inc.",
 	"license": "Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@sailpoint/connector-sdk",
-	"private": true,
 	"version": "0.0.1",
 	"description": "JavaScript framework to build SailPoint Connectors",
 	"author": "SailPoint Technologies, Inc.",


### PR DESCRIPTION
## Description
- Publish to NPM using `JS-DevTools/npm-publish@v1` action, the same tool devrel uses.
- Remove the private flag for sdk
- Set package version from github tag. Github tag is the source of truth for version, but we should still try to keep the version in packag.json up to date
- Update copyright

## How Has This Been Tested?
Tested by forking it and deploy to npm from there.
https://www.npmjs.com/package/@sailpoint/connector-sdk
