### PR TITLE
PLTCONN-2932: Allow schema to be pass down to connector process

### DIFF
--- a/lib/commands/command.ts
+++ b/lib/commands/command.ts
@@ -135,16 +135,24 @@ export type CommandState = {
 }
 
 /**
+ * The common schema
+ */
+export type Schema = {
+	displayAttribute: string
+	identityAttribute: string
+	attributes: SchemaAttribute[]
+}
+
+/**
  * Account schema
  */
-export type AccountSchema = { groupAttribute: string } & EntitlementSchema
+export type AccountSchema = Schema & {
+	groupAttribute: string
+}
 
 /**
  * Entitlement schema
  */
-export type EntitlementSchema = {
+export type EntitlementSchema = Schema & {
 	type: string
-	displayAttribute: string
-	identityAttribute: string
-	attributes: SchemaAttribute[]
 }

--- a/lib/commands/command.ts
+++ b/lib/commands/command.ts
@@ -41,7 +41,7 @@ export type SchemaAttribute = {
 	name: string,
 	description: string,
 	type: string,
-	required: boolean,
+	required?: boolean,
 	multi?: boolean,
 	managed?: boolean,
 	entitlement?: boolean

--- a/lib/commands/command.ts
+++ b/lib/commands/command.ts
@@ -41,6 +41,7 @@ export type SchemaAttribute = {
 	name: string,
 	description: string,
 	type: string,
+	required: boolean,
 	multi?: boolean,
 	managed?: boolean,
 	entitlement?: boolean
@@ -131,4 +132,19 @@ export type ObjectOutput = { identity: string, uuid?: string } | { key: Key }
  */
 export type CommandState = {
 	[key: string]: any
+}
+
+/**
+ * Account schema
+ */
+export type AccountSchema = { groupAttribute: string } & EntitlementSchema
+
+/**
+ * Entitlement schema
+ */
+export type EntitlementSchema = {
+	type: string
+	displayAttribute: string
+	identityAttribute: string
+	attributes: SchemaAttribute[]
 }

--- a/lib/commands/std-account-create.ts
+++ b/lib/commands/std-account-create.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectOutput } from './command'
+import { AccountSchema, Attributes, ObjectOutput } from './command'
 
 /**
  * Input object of `std:account:create` command
@@ -8,6 +8,7 @@ import { Attributes, ObjectOutput } from './command'
 export type StdAccountCreateInput = {
 	identity?: string
 	attributes: any
+	schema?: AccountSchema
 }
 
 /**

--- a/lib/commands/std-account-delete.ts
+++ b/lib/commands/std-account-delete.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import {ObjectInput} from "./command"
+import {AccountSchema, ObjectInput} from "./command"
 
 /**
  * Input object of `std:account:delete` command
  */
-export type StdAccountDeleteInput = ObjectInput
+export type StdAccountDeleteInput = ObjectInput & {
+	schema?: AccountSchema
+}
 
 /**
  * Output object of `std:account:delete` command

--- a/lib/commands/std-account-disable.ts
+++ b/lib/commands/std-account-disable.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2022. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectInput, ObjectOutput } from './command'
+import { AccountSchema, Attributes, ObjectInput, ObjectOutput } from './command'
 
 /**
  * Input object of `std:account:disable` command
  */
-export type StdAccountDisableInput = ObjectInput
+export type StdAccountDisableInput = ObjectInput & {
+	schema?: AccountSchema
+}
 
 /**
  * Output object of `std:account:disable` command

--- a/lib/commands/std-account-discover-schema.ts
+++ b/lib/commands/std-account-discover-schema.ts
@@ -1,13 +1,8 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { SchemaAttribute } from "./command";
+import { AccountSchema } from "./command";
 
 /**
  * Output object of `std:account:discover-schema` command
  */
-export type StdAccountDiscoverSchemaOutput = {
-	displayAttribute: string
-	groupAttribute: string
-	identityAttribute: string
-	attributes: SchemaAttribute[]
-}
+export type StdAccountDiscoverSchemaOutput = AccountSchema

--- a/lib/commands/std-account-enable.ts
+++ b/lib/commands/std-account-enable.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2022. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectInput, ObjectOutput } from './command'
+import { AccountSchema, Attributes, ObjectInput, ObjectOutput } from './command'
 
 /**
  * Input object of `std:account:enable` command
  */
-export type StdAccountEnableInput = ObjectInput
+export type StdAccountEnableInput = ObjectInput & {
+	schema?: AccountSchema
+}
 
 /**
  * Output object of `std:account:enable` command

--- a/lib/commands/std-account-list.ts
+++ b/lib/commands/std-account-list.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, CommandState, ObjectOutput } from './command'
+import { AccountSchema, Attributes, CommandState, ObjectOutput } from './command'
 
 /**
  * Input object of `std:account:list` command
@@ -8,6 +8,7 @@ import { Attributes, CommandState, ObjectOutput } from './command'
 export type StdAccountListInput = {
 	stateful?: boolean
 	state?: CommandState
+	schema?: AccountSchema
 }
 
 /**

--- a/lib/commands/std-account-read.ts
+++ b/lib/commands/std-account-read.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectInput, ObjectOutput } from './command'
+import { AccountSchema, Attributes, ObjectInput, ObjectOutput } from './command'
 
 /**
  * Input object of `std:account:read` command
  */
-export type StdAccountReadInput = ObjectInput
+export type StdAccountReadInput = ObjectInput & {
+	schema?: AccountSchema
+}
 
 /**
  * Output object of `std:account:read` command

--- a/lib/commands/std-account-unlock.ts
+++ b/lib/commands/std-account-unlock.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2022. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectInput, ObjectOutput } from './command'
+import { AccountSchema, Attributes, ObjectInput, ObjectOutput } from './command'
 
 /**
  * Input object of `std:account:unlock` command
  */
-export type StdAccountUnlockInput = ObjectInput
+export type StdAccountUnlockInput = ObjectInput & {
+	schema?: AccountSchema
+}
 
 /**
  * Output object of `std:account:unlock` command

--- a/lib/commands/std-account-update.ts
+++ b/lib/commands/std-account-update.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectInput, ObjectOutput } from './command'
+import { AccountSchema, Attributes, ObjectInput, ObjectOutput } from './command'
 
 export enum AttributeChangeOp {
 	Add = 'Add',
@@ -22,6 +22,7 @@ export type AttributeChange = {
  */
 export type StdAccountUpdateInput = ObjectInput & {
 	changes: AttributeChange[]
+	schema?: AccountSchema
 }
 
 /**

--- a/lib/commands/std-entitlement-list.ts
+++ b/lib/commands/std-entitlement-list.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, CommandState, ObjectOutput } from './command'
+import { Attributes, CommandState, EntitlementSchema, ObjectOutput } from './command'
 
 /**
  * Input object of `std:entitlement:list` command
@@ -9,6 +9,7 @@ export type StdEntitlementListInput = {
 	type: string
 	stateful?: boolean
 	state?: CommandState
+	schema?: EntitlementSchema
 }
 
 /**

--- a/lib/commands/std-entitlement-read.ts
+++ b/lib/commands/std-entitlement-read.ts
@@ -1,12 +1,13 @@
 /* Copyright (c) 2021. SailPoint Technologies, Inc. All rights reserved. */
 
-import { Attributes, ObjectInput, ObjectOutput } from './command'
+import { Attributes, EntitlementSchema, ObjectInput, ObjectOutput } from './command'
 
 /**
  * Input object of `std:entitlement:read` command
  */
 export type StdEntitlementReadInput = ObjectInput & {
 	type: string
+	schema?: EntitlementSchema
 }
 
 /**


### PR DESCRIPTION
## Description
Allow schema to be passed down to the connector process

## How Has This Been Tested?
Manually tested via API call to invoke the command, and the send out the command to webhook.site to validate input.

<img width="1713" alt="Screenshot 2023-04-28 at 9 22 14 AM" src="https://user-images.githubusercontent.com/42616890/235220363-9a0697c1-3922-475d-ba72-d2c712508134.png">


 