### PR TITLE
PLTCONN-3848: Fix error handling for connector and after handler process

### DIFF
--- a/lib/connector.spec.ts
+++ b/lib/connector.spec.ts
@@ -301,6 +301,27 @@ describe('connector errors', () => {
 			expect(e).toStrictEqual(new Error(`unsupported command: ${StandardCommand.StdTestConnection}`))
 		}
 	})
+
+	it('should customizer after handler error be handled gracefully', async () => {
+		const connector = createConnector()
+		.stdTestConnection(async (context, input, res) => {
+			res.send({})
+		})
+
+		const customizer = createConnectorCustomizer()
+			.afterStdTestConnection(async (context, output) => {
+				throw new Error('Error from customizer')
+			})
+
+		try {
+			await connector._exec(StandardCommand.StdTestConnection, MOCK_CONTEXT, {},
+				new PassThrough({ objectMode: true }).on('data', (chunk) => fail('no data should be received here')), customizer)
+
+			fail('connector execution should not success');
+		} catch (e) {
+			expect(e).toStrictEqual(new Error('Error from customizer'))
+		}
+	})
 })
 
 describe('read config', () => {

--- a/lib/connector.ts
+++ b/lib/connector.ts
@@ -249,8 +249,12 @@ export class Connector {
 					reject(e)
 				})
 
-				await handler(context, input, new ResponseStream<any>(resInterceptor))
-				resInterceptor.end()
+				try {
+					await handler(context, input, new ResponseStream<any>(resInterceptor))
+					resInterceptor.end()
+				} catch (e: any) {
+					reject(e)
+				}
 			})
 		})
 


### PR DESCRIPTION
## Description
Fix error handling for connector and after handler process

## How Has This Been Tested?
Newly added unit tests to test:
- Connector error itself
- Before handler error
- After handler error

Manual testing on this:
<img width="1167" alt="Screenshot 2023-09-14 at 9 47 13 PM" src="https://github.com/sailpoint-oss/sp-connector-sdk-js/assets/42616890/1ed5ee40-0c13-426f-b99b-79c94dbd1648">

