### PR TITLE
PLTCONN-3852: Change object output format to make identity & uuid more accessible

### DIFF
--- a/lib/commands/command.ts
+++ b/lib/commands/command.ts
@@ -128,7 +128,7 @@ export type ObjectInput = {
 	key: Key
 }
 
-export type ObjectOutput = { identity: string, uuid?: string } | { key: Key }
+export type ObjectOutput = { identity?: string, uuid?: string } & { key?: Key }
 
 /**
  * State input for stateful command


### PR DESCRIPTION
## Description
As suggested by Philip, we want to make object output more flexible so that uuid, identity or key are more accessible from customizer perspective. Here's the conversation and the customizer code showing that the three attributes being more accessible. 

<img width="790" alt="Screenshot 2023-09-18 at 12 43 46 PM" src="https://github.com/sailpoint-oss/sp-connector-sdk-js/assets/42616890/bcd7a6c8-85e8-4aac-83ed-b3106fbc24df">

<img width="776" alt="Screenshot 2023-09-18 at 12 42 05 PM" src="https://github.com/sailpoint-oss/sp-connector-sdk-js/assets/42616890/bd95d1a1-1305-4bab-989d-8d8508b73289">

## How Has This Been Tested?
What testing have you done to verify this change?
