### PR TITLE
PLTCONN-3953: Update PRB to node18. Fix test failure

### DIFF
--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ '16' ]
+        node-version: [ '18' ]
 
     steps:
       - name: Checkout

--- a/lib/connector.spec.ts
+++ b/lib/connector.spec.ts
@@ -310,8 +310,8 @@ describe('connector errors', () => {
 
 		try {
 			await connector._exec(StandardCommand.StdTestConnection, MOCK_CONTEXT, undefined,
-				new PassThrough({ objectMode: true }).on('data', (chunk) => fail('no data should be received here')))
-			fail('connector execution should not work')
+				new PassThrough({ objectMode: true }).on('data', (chunk) => {throw new Error('no data should be received here')}))
+			throw new Error('connector execution should not work')
 		} catch (e) {
 			expect(e).toStrictEqual(new Error('Error from connector'))
 		}
@@ -330,9 +330,9 @@ describe('connector errors', () => {
 
 		try {
 			await connector._exec(StandardCommand.StdTestConnection, MOCK_CONTEXT, undefined,
-				new PassThrough({ objectMode: true }).on('data', (chunk) => fail('no data should be received here')), customizer)
+				new PassThrough({ objectMode: true }).on('data', (chunk) => {throw new Error('no data should be received here')}), customizer)
 
-			fail('connector execution should not work')
+			throw new Error('connector execution should not work')
 		} catch (e) {
 			expect(e).toStrictEqual(new Error('Error from customizer after handler'))
 		}
@@ -351,9 +351,11 @@ describe('connector errors', () => {
 
 		try {
 			await connector._exec(StandardCommand.StdTestConnection, MOCK_CONTEXT, undefined,
-				new PassThrough({ objectMode: true }).on('data', (chunk) => fail('no data should be received here')), customizer)
+				new PassThrough({ objectMode: true }).on('data', (chunk) => {
+          throw new Error('no data should be received here')
+        }), customizer)
 
-			fail('connector execution should not work')
+			throw new Error('connector execution should not work')
 		} catch (e) {
 			expect(e).toStrictEqual(new Error('Error from customizer before handler'))
 		}

--- a/lib/connector.ts
+++ b/lib/connector.ts
@@ -231,13 +231,13 @@ export class Connector {
 					if (rawResponse.type == ResponseType.Output) {
 						try {
 							rawResponse.data = await afterHandler!(context, rawResponse.data)
+							res.write(rawResponse)
+							callback()
 						} catch (e: any) {
 							callback(e)
 						}
 					}
 
-					res.write(rawResponse)
-					callback()
 				},
 			})
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"dist/**/*"
 	],
 	"engines": {
-		"node": ">=16.2.0"
+		"node": ">=18.12.0"
 	},
 	"scripts": {
 		"clean": "shx rm -rf ./dist ./coverage",


### PR DESCRIPTION
## Description

A few related changes here:

1. Update PRB to node18.
2. Update tests to throw an error instead of calling fail which was removed when jest moved to jest-circus test runner.
3. Fix a bug that surfaced with node18 where we still write the command response even if the after handler fails.
