### PR TITLE
PLTCONN-5804: set shell to true when using spawn

### DIFF
--- a/bin/spcx.ts
+++ b/bin/spcx.ts
@@ -70,7 +70,7 @@ function runDev() {
 	 * spawn will fail in pure JS projects as typescript devDependency is expected to be missing
 	 */
 	const spawnTsc = (): ChildProcessWithoutNullStreams => {
-		const tsc = spawn(/^win/.test(process.platform) ? 'tsc.cmd' : 'tsc', ['--inlineSourcemap', 'true', '--sourceMap', 'false', '--watch'])
+		const tsc = spawn(/^win/.test(process.platform) ? 'tsc.cmd' : 'tsc', ['--inlineSourcemap', 'true', '--sourceMap', 'false', '--watch'], { shell: true })
 			.once('spawn', () => {
 				tsc.stdout.on('data', (data) => console.log(`tsc: ${data}`))
 				tsc.stderr.on('data', (data) => console.error(`tsc: ${data}`))


### PR DESCRIPTION
## Description
fix "npm run dev" error when node version is updated to latest.
Note: this bug is happening for Windows host devices

## How Has This Been Tested?
What testing have you done to verify this change?
manual testing.

before change
<img width="535" alt="Screenshot 2024-08-09 at 1 46 36 p m" src="https://github.com/user-attachments/assets/8a498ebe-0fd0-4122-860e-92b8fefee26f">

after change
<img width="407" alt="Screenshot 2024-08-09 at 1 45 09 p m" src="https://github.com/user-attachments/assets/e594b7d2-e4d0-49be-b3d9-5aade11c2bbd">
