### PR TITLE
Support account aggregation filtering for saas 2 0 connectors type script based (Generic Filter Class which can be imported in any connector)

### DIFF
--- a/lib/filter.spec.ts
+++ b/lib/filter.spec.ts
@@ -1,0 +1,137 @@
+import { Filter } from './filter';
+describe('Filter class', () => {
+  let filterInstance: Filter;
+
+  beforeEach(() => {
+    // set up some mock data for testing
+    const data = {
+      name: 'Alice',
+      age: 30,
+      email: 'alice@example.com',
+      address: ['Pune','Austin'],
+      department: '',
+    }
+    filterInstance = new Filter(data);
+  });
+
+  test('should apply binary expression filters', () => {
+    // equal to
+    expect(filterInstance.matcher('name == "Alice"')).toBe(true);
+
+    // not equal to
+    expect(filterInstance.matcher('age != 25')).toBe(true);
+    expect(filterInstance.matcher('age != 30')).toBe(false);
+
+    // greater than
+    expect(filterInstance.matcher('age > 25')).toBe(true);
+    expect(filterInstance.matcher('age > 35')).toBe(false);
+
+    // less than
+    expect(filterInstance.matcher('age < 35')).toBe(true);
+    expect(filterInstance.matcher('age < 25')).toBe(false);
+
+    // greater than or equal to
+    expect(filterInstance.matcher('age >= 30')).toBe(true);
+    expect(filterInstance.matcher('age >= 40')).toBe(false);
+
+    // less than or equal to
+    expect(filterInstance.matcher('age <= 30')).toBe(true);
+    expect(filterInstance.matcher('age <= 25')).toBe(false);
+
+    // strict equality
+    expect(filterInstance.matcher('name == "Alice"')).toBe(true);
+    expect(filterInstance.matcher('name == "Tom"')).toBe(false);
+
+    // invert operation (! NOT operation)
+    expect(filterInstance.matcher('!(name == "Alice")')).toBe(false);
+    expect(filterInstance.matcher('!(name == "Tom")')).toBe(true);
+  });
+
+  test('should apply logical AND filter (&&)', () => {
+    const filterString = 'age > 25 && name === "Alice"';
+    expect(filterInstance.matcher(filterString)).toBe(true);
+
+    const filterStringFalse = 'age < 25 && name === "Alice"';
+    expect(filterInstance.matcher(filterStringFalse)).toBe(false);
+  });
+
+  test('should apply logical OR filter (||)', () => {
+    const filterString = 'age < 25 || name === "Alice"';
+    expect(filterInstance.matcher(filterString)).toBe(true);
+
+    const filterStringFalse = 'age < 25 || name === "Tom"';
+    expect(filterInstance.matcher(filterStringFalse)).toBe(false);
+  });
+
+  test('should apply call expression filters', () => {
+    // isNull
+    expect(filterInstance.matcher('name.isNull()')).toBe(false);  // 'name' is 'Alice'
+    expect(filterInstance.matcher('email.isNull()')).toBe(false); // 'email' is 'alice@example.com'
+
+    // notNull
+    expect(filterInstance.matcher('name.notNull()')).toBe(true);
+    expect(filterInstance.matcher('email.notNull()')).toBe(true);
+
+    // isEmpty
+    expect(filterInstance.matcher('department.isEmpty()')).toBe(true);
+    expect(filterInstance.matcher('name.isEmpty()')).toBe(false);
+
+    // notEmpty
+    expect(filterInstance.matcher('department.notEmpty()')).toBe(false);
+    expect(filterInstance.matcher('name.notEmpty()')).toBe(true);
+
+    // startsWith
+    expect(filterInstance.matcher('email.startsWith("alice")')).toBe(true);
+    expect(filterInstance.matcher('email.startsWith("tom")')).toBe(false);
+
+    // endsWith
+    expect(filterInstance.matcher('email.endsWith("example.com")')).toBe(true);
+    expect(filterInstance.matcher('email.endsWith("gmail.com")')).toBe(false);
+
+    // contains
+    expect(filterInstance.matcher('email.contains("example")')).toBe(true);
+    expect(filterInstance.matcher('email.contains("yahoo")')).toBe(false);
+
+    // containsAll
+     expect(filterInstance.matcher('address.containsAll("Pune", "Austin")')).toBe(true);
+     expect(filterInstance.matcher('address.containsAll("Pune", "NY")')).toBe(false);
+
+    // startsWithIgnoreCase
+    expect(filterInstance.matcher('email.startsWithIgnoreCase("rit")')).toBe(true);
+    expect(filterInstance.matcher('email.startsWithIgnoreCase("ali")')).toBe(false);
+
+    // endsWithIgnoreCase
+    expect(filterInstance.matcher('email.endsWithIgnoreCase(".org")')).toBe(true);
+    expect(filterInstance.matcher('email.endsWithIgnoreCase(".com")')).toBe(false);
+
+    // containsIgnoreCase
+    expect(filterInstance.matcher('email.containsIgnoreCase("google")')).toBe(true);
+    expect(filterInstance.matcher('email.containsIgnoreCase("example")')).toBe(false);
+
+    // containsAllIgnoreCase
+    expect(filterInstance.matcher('address.containsAllIgnoreCase("NY", "Texas")')).toBe(true);
+    expect(filterInstance.matcher('address.containsAllIgnoreCase("Pune", "NY")')).toBe(false);
+  });
+
+  test('should handle AND/OR binary expression correctly', () => {
+    // binaryExpression && binaryExpression
+    expect(filterInstance.matcher('(age > 25 && name == "Alice")')).toBe(true);
+    // binaryExpression && binaryExpression
+    expect(filterInstance.matcher('(age > 25 && name != "Alice")')).toBe(false);
+    // binaryExpression && callExpression
+    expect(filterInstance.matcher('(age > 25 && department.isEmpty())')).toBe(true);
+    // binaryExpression && callExpression
+    expect(filterInstance.matcher('(age > 25 && department.notEmpty())')).toBe(false);
+    // callExpression && callExpression
+    expect(filterInstance.matcher('(name.isEmpty() && department.notEmpty())')).toBe(false);
+
+    // binaryExpression || binaryExpression
+    expect(filterInstance.matcher('(age < 25 || name == "Alice")')).toBe(true);
+    // binaryExpression || binaryExpression
+    expect(filterInstance.matcher('(age > 25 || name == "Alice")')).toBe(true);
+    // binaryExpression || callExpression
+    expect(filterInstance.matcher('(age > 25 || name.isEmpty())')).toBe(false);
+    // callExpression || callExpression
+    expect(filterInstance.matcher('(department.notEmpty() || name.isEmpty())')).toBe(false);
+  });
+});

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -8,7 +8,7 @@ export class Filter {
   }
 
   // matcher decides which operation to be performed based on resource object based on the provided filter object
-  public matcher(filterString: string): boolean {
+  public matcher(filterString: string) {
     let filter = jsep(filterString);
     switch (true) {
       case (filter.type === 'BinaryExpression' && filter.operator !== '&&' && filter.operator !== '||'):
@@ -21,8 +21,6 @@ export class Filter {
         return this.applyAndBinaryExpressionFilter(filter);
       case (filter.operator === '||'):
         return this.applyOrBinaryExpressionFilter(filter);
-      default:
-        throw new Error(`Unknown operator: ${filter.operator}`);
     }
   }
 
@@ -35,7 +33,7 @@ export class Filter {
   //  right: { type: 'Literal', value: 20 }
   //};
   // applyBinaryExpressionFilter applies binarry filters on an objects
-  private applyBinaryExpressionFilter(filter: any): boolean {
+  private applyBinaryExpressionFilter(filter: any) {
     // check the type of the filter, which should be BinaryExpression for comparison
     if (filter.type === 'BinaryExpression') {
       const left = filter.left; // left part (field to compare)
@@ -59,15 +57,12 @@ export class Filter {
           return leftValue <= right.value;
         case '!=':  // inequality check
           return leftValue != right.value;
-        default:
-          throw new Error(`Unknown operator: ${operator}`);
       }
     }
-    throw new Error('Unsupported filter type');
   }
 
   // a mock of the isNull method that could be attached to an object like 'email' 'name' etc..
-  private isNullorEmpty(value: any): boolean {
+  private isNullorEmpty(value: any) {
     return value === null || value === undefined || value === '';
   }
 
@@ -84,7 +79,7 @@ export class Filter {
   //   }
   // };
   // applyCallExpressionFilte applies filter based on CallExpression
-  private applyCallExpressionFilter(filter: any): boolean {
+  private applyCallExpressionFilter(filter: any) {
     // check if the filter is a CallExpression
     if (filter.type === 'CallExpression') {
       const callee = filter.callee;  // the MemberExpression for the method call
@@ -122,14 +117,9 @@ export class Filter {
           case 'containsAllIgnoreCase':// Check if the method is `containsAllIgnoreCase` and apply it to the value
             // ensure all values are present in the property
             return args.every((arg: { value: string }) => !value.includes(arg.value));// apply the containsAllIgnoreCase method
-          default:
-            throw new Error(`Unsupported method: ${methodName}`);
         }
-      } else {
-        throw new Error(`Object ${objectName} not found in the data`);
       }
     }
-    throw new Error('Unsupported filter type');
   }
 
   // filterString Example: ( type == "Employee" && location == "Austin" )
@@ -161,7 +151,7 @@ export class Filter {
   //     }
   //   }
   // applyAndBinaryExpressionFilter applies AND BinaryExpression and CallExpression filters
-  private applyAndBinaryExpressionFilter(filter: any): boolean {
+  private applyAndBinaryExpressionFilter(filter: any){
     let currentFilter = filter;
     let rightValue = [];
     let leftValue = [];
@@ -216,7 +206,7 @@ export class Filter {
   //     }
   //   }
   //  applyOrBinaryExpressionFilter applies OR BinaryExpression and CallExpression filters
-  private applyOrBinaryExpressionFilter(filter: any): boolean {
+  private applyOrBinaryExpressionFilter(filter: any){
     let currentFilter = filter;
     let rightValue = [];
     let leftValue = [];
@@ -244,20 +234,5 @@ export class Filter {
 }
 
 
-
-
-// Example Usage
-const data = {
-  firstName: null,
-  type: null,
-  email: null,
-  company: "SailPoint",
-  age: 21,
-  address: [],
-};
-
-const filterString = '( company == "SailPoint" )';
-const filterEvaluator = new Filter(data);
-const result = filterEvaluator.matcher(filterString);
-
-console.log(result); // Output should be true if company equals "SailPoint"
+//const filterEvaluator = new Filter(data);
+//const result = filterEvaluator.matcher(filterString);

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -232,7 +232,3 @@ export class Filter {
     return rightValue.some(Boolean) || leftValue.some(Boolean);
   }
 }
-
-
-//const filterEvaluator = new Filter(data);
-//const result = filterEvaluator.matcher(filterString);

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -1,0 +1,263 @@
+const jsep = require("jsep");
+
+export class Filter {
+  private data: any;
+
+  constructor(data: any) {
+    this.data = data;
+  }
+
+  // matcher decides which operation to be performed based on resource object based on the provided filter object
+  public matcher(filterString: string): boolean {
+    let filter = jsep(filterString);
+    switch (true) {
+      case (filter.type === 'BinaryExpression' && filter.operator !== '&&' && filter.operator !== '||'):
+        return this.applyBinaryExpressionFilter(filter);
+      case (filter.type === 'CallExpression' && filter.operator !== '&&' && filter.operator !== '||'):
+        return this.applyCallExpressionFilter(filter);
+      case (filter.operator === '!'):
+        return !this.applyBinaryExpressionFilter(filter.argument);
+      case (filter.operator === '&&'):
+        return this.applyAndBinaryExpressionFilter(filter);
+      case (filter.operator === '||'):
+        return this.applyOrBinaryExpressionFilter(filter);
+      default:
+        throw new Error(`Unknown operator: ${filter.operator}`);
+    }
+  }
+
+  // filterString Example: (age > 20)
+  // Filter evaluter Example :
+  //{
+  //  type: 'BinaryExpression',
+  //  operator: '>',
+  //  left: { type: 'Identifier', name: 'age' },
+  //  right: { type: 'Literal', value: 20 }
+  //};
+  // applyBinaryExpressionFilter applies binarry filters on an objects
+  private applyBinaryExpressionFilter(filter: any): boolean {
+    // check the type of the filter, which should be BinaryExpression for comparison
+    if (filter.type === 'BinaryExpression') {
+      const left = filter.left; // left part (field to compare)
+      const right = filter.right; // right part (value to compare against)
+      const operator = filter.operator;  // comparison operator
+      // retrieve the field value from the object (e.g., obj[firstName])
+      const leftValue = this.data[left.name];
+
+      switch (operator) {
+        case '==':  // equality check
+          return leftValue == right.value;
+        case '===': // strict equality check
+          return leftValue === right.value;
+        case '>': // greater than check
+          return leftValue > right.value;
+        case '<': // less than check
+          return leftValue < right.value;
+        case '>=': // greater than or equal check
+          return leftValue >= right.value;
+        case '<=': // less than or equal check
+          return leftValue <= right.value;
+        case '!=':  // inequality check
+          return leftValue != right.value;
+        default:
+          throw new Error(`Unknown operator: ${operator}`);
+      }
+    }
+    throw new Error('Unsupported filter type');
+  }
+
+  // a mock of the isNull method that could be attached to an object like 'email' 'name' etc..
+  private isNullorEmpty(value: any): boolean {
+    return value === null || value === undefined || value === '';
+  }
+
+  // filterString Example: email.isNull()
+  // Filter evaluter output Example for CallExpression :
+  // {
+  // type: 'CallExpression',
+  // arguments: [],
+  // callee: {
+  //    type: 'MemberExpression',
+  //    computed: false,
+  //    object: { type: 'Identifier', name: 'email' },
+  //    property: { type: 'Identifier', name: 'isNull' }
+  //   }
+  // };
+  // applyCallExpressionFilte applies filter based on CallExpression
+  private applyCallExpressionFilter(filter: any): boolean {
+    // check if the filter is a CallExpression
+    if (filter.type === 'CallExpression') {
+      const callee = filter.callee;  // the MemberExpression for the method call
+      const objectName = callee.object.name; // the object name (e.g., 'email')
+      const methodName = callee.property.name;  // the method name (e.g., 'isNull')
+      const args = filter.arguments;
+
+      // check if the object in the filter matches the object's name in the input data
+      if (this.data.hasOwnProperty(objectName)) {
+        const value = this.data[objectName]; // get the value of the object (e.g., email)
+        switch (methodName) {
+          case 'isNull':  // check if the method is `isNull` and apply it to the value
+            return this.isNullorEmpty(value);  // apply the isNull method
+          case 'notNull': // check if the method is `notNull` and apply it to the value
+            return !this.isNullorEmpty(value); // apply the notNull method
+          case 'isEmpty':  // check if the method is `isEmpty` and apply it to the value
+            return this.isNullorEmpty(value);  // apply the isEmpty method
+          case 'notEmpty': // check if the method is `notEmpty` and apply it to the value
+            return !this.isNullorEmpty(value);  // apply the notEmpty method
+          case 'startsWith':  // check if the method is `startsWith` and apply it to the value
+            return value.startsWith(args[0].value); // apply the startsWith method
+          case 'endsWith': // check if the method is `endsWith` and apply it to the value
+            return value.endsWith(args[0].value);  // apply the endsWith method
+          case 'startsWithIgnoreCase':  // check if the method is `startsWithIgnoreCase` and apply it to the value
+            return !value.startsWith(args[0].value);  // apply the startsWithIgnoreCase method
+          case 'endsWithIgnoreCase': // check if the method is `endsWithIgnoreCase` and apply it to the value
+            return !value.endsWith(args[0].value);  // apply the endsWithIgnoreCase method
+          case 'contains':  // check if the method is `contains` and apply it to the value
+            return value.includes(args[0].value); // apply the contains method
+          case 'containsIgnoreCase':  // check if the method is `containsIgnoreCase` and apply it to the value
+            return !value.includes(args[0].value); // apply the containsIgnoreCase method
+          case 'containsAll':// Check if the method is `containsAll` and apply it to the value
+            // ensure all values are present in the property
+            return args.every((arg: { value: string }) => value.includes(arg.value)); // apply the containsAll method
+          case 'containsAllIgnoreCase':// Check if the method is `containsAllIgnoreCase` and apply it to the value
+            // ensure all values are present in the property
+            return args.every((arg: { value: string }) => !value.includes(arg.value));// apply the containsAllIgnoreCase method
+          default:
+            throw new Error(`Unsupported method: ${methodName}`);
+        }
+      } else {
+        throw new Error(`Object ${objectName} not found in the data`);
+      }
+    }
+    throw new Error('Unsupported filter type');
+  }
+
+  // filterString Example: ( type == "Employee" && location == "Austin" )
+  // Filter Evaluator Example for AND operation with multiple expressions:
+  // {
+  //     type: 'BinaryExpression',
+  //     operator: '&&',
+  //     left: {
+  //       type: 'BinaryExpression',
+  //       operator: '&&',
+  //       left: {
+  //         type: 'BinaryExpression',
+  //         operator: '==',
+  //         left: [Object],
+  //         right: [Object]
+  //       },
+  //       right: {
+  //         type: 'BinaryExpression',
+  //         operator: '==',
+  //         left: [Object],
+  //         right: [Object]
+  //       }
+  //     },
+  //     right: {
+  //       type: 'BinaryExpression',
+  //       operator: '==',
+  //       left: { type: 'Identifier', name: 'age' },
+  //       right: { type: 'Literal', value: null, raw: 'null' }
+  //     }
+  //   }
+  // applyAndBinaryExpressionFilter applies AND BinaryExpression and CallExpression filters
+  private applyAndBinaryExpressionFilter(filter: any): boolean {
+    let currentFilter = filter;
+    let rightValue = [];
+    let leftValue = [];
+
+    // keep processing the filter as long as we have '&&' operators
+    while (currentFilter.operator === '&&') {
+      if (currentFilter.right.type === 'BinaryExpression') {
+        // evaluate the right part of the current '&&' expression
+        rightValue.push(this.applyBinaryExpressionFilter(currentFilter.right));
+        currentFilter = currentFilter.left;
+        if (currentFilter.operator !== '&&' && currentFilter.type === 'BinaryExpression') {
+          leftValue.push(this.applyBinaryExpressionFilter(currentFilter));
+        }
+      } else {
+        // evaluate the right part of the current '&&' expression
+        rightValue.push(this.applyCallExpressionFilter(currentFilter.right));
+        currentFilter = currentFilter.left;
+        if (currentFilter.operator !== '&&' && currentFilter.type === 'CallExpression') {
+          leftValue.push(this.applyCallExpressionFilter(currentFilter));
+        }
+      }
+    }
+    return rightValue.every(Boolean) && leftValue.every(Boolean);
+  }
+
+  // filterString Example: ( type == "Employee" || location == "Austin" )
+  // Filter Evaluator Example for OR operation with multiple expressions:
+  // {
+  //     type: 'BinaryExpression',
+  //     operator: '||',
+  //     left: {
+  //       type: 'BinaryExpression',
+  //       operator: '||',
+  //       left: {
+  //         type: 'BinaryExpression',
+  //         operator: '==',
+  //         left: [Object],
+  //         right: [Object]
+  //       },
+  //       right: {
+  //         type: 'BinaryExpression',
+  //         operator: '==',
+  //         left: [Object],
+  //         right: [Object]
+  //       }
+  //     },
+  //     right: {
+  //       type: 'BinaryExpression',
+  //       operator: '==',
+  //       left: { type: 'Identifier', name: 'age' },
+  //       right: { type: 'Literal', value: null, raw: 'null' }
+  //     }
+  //   }
+  //  applyOrBinaryExpressionFilter applies OR BinaryExpression and CallExpression filters
+  private applyOrBinaryExpressionFilter(filter: any): boolean {
+    let currentFilter = filter;
+    let rightValue = [];
+    let leftValue = [];
+
+    // keep processing the filter as long as we have '||' operators
+    while (currentFilter.operator === '||') {
+      if (currentFilter.right.type === 'BinaryExpression') {
+        // evaluate the right part of the current '||' expression
+        rightValue.push(this.applyBinaryExpressionFilter(currentFilter.right));
+        currentFilter = currentFilter.left;
+        if (currentFilter.operator !== '||' && currentFilter.type === 'BinaryExpression') {
+          leftValue.push(this.applyBinaryExpressionFilter(currentFilter));
+        }
+      } else {
+        // evaluate the right part of the current '||' expression
+        rightValue.push(this.applyCallExpressionFilter(currentFilter.right));
+        currentFilter = currentFilter.left;
+        if (currentFilter.operator !== '||' && currentFilter.type === 'CallExpression') {
+          leftValue.push(this.applyCallExpressionFilter(currentFilter));
+        }
+      }
+    }
+    return rightValue.some(Boolean) || leftValue.some(Boolean);
+  }
+}
+
+
+
+
+// Example Usage
+const data = {
+  firstName: null,
+  type: null,
+  email: null,
+  company: "SailPoint",
+  age: 21,
+  address: [],
+};
+
+const filterString = '( company == "SailPoint" )';
+const filterEvaluator = new Filter(data);
+const result = filterEvaluator.matcher(filterString);
+
+console.log(result); // Output should be true if company equals "SailPoint"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,3 +10,4 @@ export * from './connector-customizer-handler'
 export * from './response'
 export * from './logger'
 export * from './partitionAdapter'
+export * from './filter';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"archiver": "^7.0.1",
 				"debug": "^4.3.7",
 				"express": "^5.0.1",
+				"jsep": "^1.4.0",
 				"pino": "^8.5.0"
 			},
 			"bin": {
@@ -2309,10 +2310,9 @@
 			"dev": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"license": "MIT",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -3964,6 +3964,14 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsep": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+			"engines": {
+				"node": ">= 10.16.0"
 			}
 		},
 		"node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"archiver": "^7.0.1",
 		"debug": "^4.3.7",
 		"express": "^5.0.1",
+		"jsep": "^1.4.0",
 		"pino": "^8.5.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description
Support account aggregation filtering for saas 2 0 connectors type script based (only filter class)
Jira ticket: https://sailpoint.atlassian.net/browse/PLTCONN-7014

## How Has This Been Tested?
What testing have you done to verify this change?
> Have tested it by importing the Filter class in one of connector, the data is getting filtered as expected.
> The connector which doesn't supports native filtering via API calls will implement Filter class from here.

<img width="1212" alt="Screenshot 2025-01-21 at 2 23 28 PM" src="https://github.com/user-attachments/assets/52218a57-6f13-4123-8abb-b18073557bf7" />

