### PR TITLE
updated path to work on node 5.x

### DIFF
--- a/bin/spcx.ts
+++ b/bin/spcx.ts
@@ -110,7 +110,7 @@ function runDev() {
 
 	const app = express()
 		.use(express.json({ strict: true }))
-		.post('/*path', async (req, res) => {
+		.post('/', async (req, res) => {
 			try {
 				res.type('application/x-ndjson')
 				const cmd: Command = req.body as Command


### PR DESCRIPTION
## Description
This fixes an issue as described in https://github.com/sailpoint-oss/sp-connector-sdk-js/issues/75

## How Has This Been Tested?
Tested running connector locally and new path seems to resolve the issue
