### PR TITLE
Aggregation Filtering: should return false by default as we use negative filtering

### DIFF
--- a/lib/filter.spec.ts
+++ b/lib/filter.spec.ts
@@ -135,6 +135,13 @@ describe('Filter class', () => {
     expect(filterInstance.matcher('(department.notEmpty() || name.isEmpty())')).toBe(false);
   });
 
+  test('should handle negation (!)', () => {
+    // ! callExpression
+    expect(filterInstance.matcher('!(name.isNull())')).toBe(true);
+    // ! binaryExpression
+    expect(filterInstance.matcher('!(name == "Alice")')).toBe(false);
+  });
+
   test('should handle complex AND/OR binary expression correctly', () => {
 		// binaryExpression && binaryExpression
 		expect(

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -49,7 +49,7 @@ export class Filter {
       case '!=':
         return leftValue != rightValue
       default:
-        return true
+        return false
     }
   }
 
@@ -109,10 +109,10 @@ export class Filter {
           // ensure all values are present in the property
           return args.every((arg => !value.includes(arg.value)))// apply the containsAllIgnoreCase method
         default:
-          return true
+          return false
       }
     }
-    return true
+    return false
   }
 
   // // filterString Example 1: ( type == "Employee" && location == "Austin" )
@@ -147,8 +147,13 @@ export class Filter {
   // applyFilter applies filter based on BinaryExpression, CallExpression, UnaryExpression filters on simple and complex filter string
   private applyFilter(filter: Expression): boolean {
     if (filter.type === 'UnaryExpression' && ['!'].includes(`${filter.operator}`)) {
-      let filterArg = filter.argument as Expression
-      return !this.applyBinaryExpressionFilter(filterArg)
+      let filterArg = filter.argument as Expression;
+      if (filterArg.type === 'CallExpression') {
+        return !this.applyCallExpressionFilter(filterArg);
+      } else if (filterArg.type === 'BinaryExpression') {
+        return !this.applyBinaryExpressionFilter(filterArg);
+      }
+      return !this.applyFilter(filterArg);
     }
     // if the current expression is a comparison
     if (filter.type === 'BinaryExpression' && ['==', '===', '!=', '!==', '<', '>', '<=', '>='].includes(`${filter.operator}`)) {
@@ -172,6 +177,15 @@ export class Filter {
         return leftResult && rightResult // logical AND
       }
     }
-    return true
+    return false
   }
 }
+
+const data = {
+name:'John Dor'
+}
+const filterInstance = new Filter(data)
+
+const result = filterInstance.matcher("name.Contains(\"John\")")
+console.log("result")
+console.log(result)

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -180,12 +180,3 @@ export class Filter {
     return false
   }
 }
-
-const data = {
-name:'John Dor'
-}
-const filterInstance = new Filter(data)
-
-const result = filterInstance.matcher("name.Contains(\"John\")")
-console.log("result")
-console.log(result)


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made?
> Added the missing support for ! operation for CallExpressionFIlter

> As we are using the negative filtering, and if we provide wrong filterString then it returns true by default, causing to skip the RO's, instead just return false and aggregate the ROs.

## How Has This Been Tested?
What testing have you done to verify this change?
> Unit test and tested it by creating zip and implementing it for one of the connector.
