### PR TITLE
PLTCONN-7763 : Customizer - Support for After Entitlement-List

### DIFF
--- a/lib/connector-customizer-handler.ts
+++ b/lib/connector-customizer-handler.ts
@@ -25,6 +25,7 @@ import {
 	StdEntitlementReadInput,
 	StdEntitlementReadOutput,
 	StdEntitlementListInput,
+	StdEntitlementListOutput,
 	StdTestConnectionInput,
 	StdTestConnectionOutput,
 	StdChangePasswordInput,
@@ -152,6 +153,11 @@ export type StdEntitlementListBeforeHandler = (
 	context: Context,
 	input: StdEntitlementListInput
 ) => Promise<StdEntitlementListInput>
+
+export type StdEntitlementListAfterHandler = (
+	context: Context,
+	output: StdEntitlementListOutput
+) => Promise<StdEntitlementListOutput>
 
 export type StdChangePasswordBeforeHandler = (
 	context: Context,

--- a/lib/connector-customizer.spec.ts
+++ b/lib/connector-customizer.spec.ts
@@ -51,6 +51,7 @@ describe('class properties and methods', () => {
 			.beforeStdEntitlementRead(async (context, input) => {return input})
 			.afterStdEntitlementRead(async (context, output) => {return output})
 			.beforeStdEntitlementList(async (context, input) => {return input})
+			.afterStdEntitlementList(async (context, output) => {return output})
 			.beforeStdChangePassword(async (context, input) => {return input})
 			.afterStdChangePassword(async (context, output) => {return output})
 			.beforeStdSourceDataDiscover(async (context, input) => {return input})
@@ -58,7 +59,7 @@ describe('class properties and methods', () => {
 			.afterStdSourceDataDiscover(async (context, output) => {return output})
 			.afterStdSourceDataRead(async (context, output) => {return output})
 
-		expect(customizer.handlers.size).toBe(33)
+		expect(customizer.handlers.size).toBe(34)
 	})
 })
 

--- a/lib/connector-customizer.ts
+++ b/lib/connector-customizer.ts
@@ -27,6 +27,7 @@ import {
 	StdEntitlementReadAfterHandler,
 	StdEntitlementReadBeforeHandler,
 	StdEntitlementListBeforeHandler,
+	StdEntitlementListAfterHandler,
 	StdChangePasswordAfterHandler,
 	StdChangePasswordBeforeHandler,
 	StdSourceDataDiscoverBeforeHandler,
@@ -300,6 +301,16 @@ export class ConnectorCustomizer {
 		this._handlers.set(this.handlerKey(CustomizerType.Before, StandardCommand.StdEntitlementList), handler)
 		return this
 	}
+
+	/**
+	 * Add a after handler for 'std:entitlement:list' command
+	 * @param handler handler
+	 */
+	afterStdEntitlementList(handler: StdEntitlementListAfterHandler): this {
+		this._handlers.set(this.handlerKey(CustomizerType.After, StandardCommand.StdEntitlementList), handler)
+		return this
+	}
+
 
 	/**
 	 * Add a before handler for 'std:change-password' command


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made?
Support  for after entitlement list customiser.

Use this logic to implement the command:
```
.afterStdEntitlementList(async (context: Context, output: StdEntitlementListOutput) => {
    logger.info(`Running after entitlement list for account  ${output.identity}`)
    return output
})
```

## How Has This Been Tested?
What testing have you done to verify this change?
