### PR TITLE
chore: rename variable to keep consistency

### DIFF
--- a/lib/connector-customizer-handler.ts
+++ b/lib/connector-customizer-handler.ts
@@ -126,7 +126,7 @@ export type StdAccountListBeforeHandler = (
 
 export type StdAccountListAfterHandler = (
 	context: Context,
-	input: StdAccountListOutput
+	output: StdAccountListOutput
 ) => Promise<StdAccountListOutput>
 
 export type StdAuthenticateBeforeHandler = (


### PR DESCRIPTION
## Description
All the hooks executed after the connector has a variable called output, except `StdAccountListAfterHandler`. I renamed that variable to keep it consistent.

## How Has This Been Tested?
Renaming a variable should not affect the tests.