### PR TITLE
CONCHENAB-7090 : Support MetaData AttributeRequest

### DIFF
--- a/lib/commands/std-account-create.ts
+++ b/lib/commands/std-account-create.ts
@@ -19,7 +19,7 @@ export type CreateAttributeMetadata = {
 export type StdAccountCreateInput = {
 	identity?: string
 	attributes: any
-	attributesWithMetadata: CreateAttributeMetadata[]
+	attributesWithMetadata?: CreateAttributeMetadata[]
 	schema?: AccountSchema
 }
 


### PR DESCRIPTION

## Description
What is the intent of this change and why is it being made?
>>>Making attributesWithMetadata as optional in StdAccountCreateInput cause few existing unit test were failing with error attributesWithMetadata not defined.
This issue is only with unit test. connector will work fine on customer env

## How Has This Been Tested?
What testing have you done to verify this change?
