### PR TITLE
kd/PLTCONN-10525-fix-vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 
 # Dependency directories
 node_modules/
+*.tgz
+
+# Accidental npm pack / extract artifacts
+/package/
 
 # Compiled source
 dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sailpoint/connector-sdk",
-	"version": "1.0.0",
+	"version": "1.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sailpoint/connector-sdk",
-			"version": "1.0.0",
+			"version": "1.2.2",
 			"license": "Copyright (c) 2023. SailPoint Technologies, Inc. All rights reserved.",
 			"dependencies": {
 				"archiver": "^7.0.1",
@@ -14,7 +14,9 @@
 				"debug": "^4.4.1",
 				"express": "^5.2.1",
 				"jsep": "^1.4.0",
-				"pino": "^8.5.0"
+				"path-to-regexp": "^8.4.0",
+				"pino": "^8.5.0",
+				"qs": "^6.14.2"
 			},
 			"bin": {
 				"spcx": "dist/bin/spcx.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sailpoint/connector-sdk",
-	"version": "1.0.0",
+	"version": "1.2.2",
 	"description": "JavaScript framework to build SailPoint Connectors",
 	"author": "SailPoint Technologies, Inc.",
 	"license": "Copyright (c) 2023. SailPoint Technologies, Inc. All rights reserved.",
@@ -33,7 +33,9 @@
 		"debug": "^4.4.1",
 		"express": "^5.2.1",
 		"jsep": "^1.4.0",
-		"pino": "^8.5.0"
+		"path-to-regexp": "^8.4.0",
+		"pino": "^8.5.0",
+		"qs": "^6.14.2"
 	},
 	"devDependencies": {
 		"@tsconfig/node16": "1.0.1",
@@ -53,7 +55,10 @@
 	},
 	"overrides": {
 		"minimist": "^1.2.6",
-		"debug": "^4.4.1"
+		"debug": "^4.4.1",
+		"lodash": "^4.18.0",
+		"path-to-regexp": "^8.4.0",
+		"qs": "^6.14.2"
 	},
 	"jest": {
 		"preset": "ts-jest",


### PR DESCRIPTION
…lities

Add direct qs and path-to-regexp floors and npm overrides for lodash, qs, and path-to-regexp. Publish version 1.2.2 on top of current OSS main.

## Description
What is the intent of this change and why is it being made?

## How Has This Been Tested?
What testing have you done to verify this change?
