### PR TITLE
chore: add Codey-Bot Jira sync config

### DIFF
--- a/.github/codey-bot.yml
+++ b/.github/codey-bot.yml
@@ -1,0 +1,31 @@
+# Codey-Bot Jira sync configuration.
+# Dry-run mode validates wiring without creating Jira issues.
+dryRun: true
+
+spam:
+  enabled: false
+community:
+  welcomeMessage: null
+  newContributorLabel: null
+  autoLabeler: {}
+pr:
+  requireBody: false
+  conventionalCommits: false
+  autoFormat: false
+qualityGate:
+  enabled: false
+stale:
+  enabled: false
+
+jiraSync:
+  enabled: true
+  projectKey: DEVREL
+  epicKey: DEVREL-2335
+  issueType: Task
+  syncIssues: true
+  syncPullRequests: false
+  labels:
+    - github-sync
+    - sailpoint-oss
+    - sdk-cli
+    - repo-sp-connector-sdk-js


### PR DESCRIPTION
## Summary
- Adds dry-run Codey-Bot Jira sync configuration for `sp-connector-sdk-js`.
- Routes GitHub issues to `DEVREL-2335` (SDKs) in the DEVREL Jira project.
- Disables non-Jira Codey-Bot features in this repo config unless maintainers opt in later.

## Jira Sync
- Project: `DEVREL`
- Epic: `DEVREL-2335`
- Issue type: `Task`
- Mode: `dryRun: true` for validation only
- Labels: `github-sync`, `sailpoint-oss`, `sdk-cli`, `repo-sp-connector-sdk-js`

## Rollout Notes
This PR does not create Jira issues while `dryRun` remains true. After maintainers verify Codey-Bot logs and the DEVREL epic destination, a follow-up PR can switch `dryRun` to false.

Generated as part of the public `sailpoint-oss` repo-to-DEVREL Jira wiring rollout.
