### PR TITLE
test/poc

### DIFF
--- a/lib/commands/std-resource-list.ts
+++ b/lib/commands/std-resource-list.ts
@@ -13,19 +13,3 @@ export type StdResourceListInput = ResourceInput & {
  * Output object of `std:resource:list` command
  */
 export type StdResourceListOutput = ResourceOutput
-
-/**
- * Input object of `std:resource:list` command when multiple datasets are requested
- */
-export type StdResourceListDatasetsInput = {
-	datasetIds: string[]
-	resourceSchemas?: Record<string, Schema[]>
-	schemas?: Schema[]
-}
-
-/**
- * Output object of `std:resource:list` command when multiple datasets are requested
- */
-export type StdResourceListDatasetsOutput = ResourceOutput & {
-	datasetId: string
-}

--- a/lib/commands/std-resource-list.ts
+++ b/lib/commands/std-resource-list.ts
@@ -13,3 +13,19 @@ export type StdResourceListInput = ResourceInput & {
  * Output object of `std:resource:list` command
  */
 export type StdResourceListOutput = ResourceOutput
+
+/**
+ * Input object of `std:resource:list` command when multiple datasets are requested
+ */
+export type StdResourceListDatasetsInput = {
+	datasetIds: string[]
+	resourceSchemas?: Record<string, Schema[]>
+	schemas?: Schema[]
+}
+
+/**
+ * Output object of `std:resource:list` command when multiple datasets are requested
+ */
+export type StdResourceListDatasetsOutput = ResourceOutput & {
+	datasetId: string
+}

--- a/lib/connector.spec.ts
+++ b/lib/connector.spec.ts
@@ -506,6 +506,56 @@ describe('exec handlers', () => {
 		})
 	})
 
+	describe('duplicate datasetIds deduplication', () => {
+		it('should invoke stdApplicationDiscoveryListWithDataset once per unique datasetId', async () => {
+			const datasetIds: string[] = []
+			const connector = createConnector().stdApplicationDiscoveryListWithDataset(async (_context, input) => {
+				datasetIds.push(input.datasetId)
+			})
+
+			await connector._exec(
+				StandardCommand.StdApplicationDiscoveryList,
+				MOCK_CONTEXT,
+				{ datasetIds: ['serviceNow:agent', 'serviceNow:agent', 'other:dataset'] },
+				new PassThrough({ objectMode: true })
+			)
+
+			expect(datasetIds).toEqual(['serviceNow:agent', 'other:dataset'])
+		})
+
+		it('should invoke stdAgentList once per unique datasetId', async () => {
+			const datasetIds: string[] = []
+			const connector = createConnector().stdAgentList(async (_context, input) => {
+				datasetIds.push(input.datasetId)
+			})
+
+			await connector._exec(
+				'std:agent:list',
+				MOCK_CONTEXT,
+				{ datasetIds: ['dataset1', 'dataset1', 'dataset2'] },
+				new PassThrough({ objectMode: true })
+			)
+
+			expect(datasetIds).toEqual(['dataset1', 'dataset2'])
+		})
+
+		it('should invoke stdMachineIdentityList once per unique datasetId', async () => {
+			const datasetIds: string[] = []
+			const connector = createConnector().stdMachineIdentityList(async (_context, input) => {
+				datasetIds.push(input.datasetId)
+			})
+
+			await connector._exec(
+				'std:machine-identity:list',
+				MOCK_CONTEXT,
+				{ datasetIds: ['serviceNow:agent', 'serviceNow:agent'] },
+				new PassThrough({ objectMode: true })
+			)
+
+			expect(datasetIds).toEqual(['serviceNow:agent'])
+		})
+	})
+
 	it('should execute stdEntitlementListHandler', async () => {
 		const connector = createConnector().stdEntitlementList(async (context, input, res) => {
 			expect(context).toBeDefined()

--- a/lib/connector.spec.ts
+++ b/lib/connector.spec.ts
@@ -554,22 +554,6 @@ describe('exec handlers', () => {
 
 			expect(datasetIds).toEqual(['serviceNow:agent'])
 		})
-
-		it('should invoke stdResourceList once per unique datasetId', async () => {
-			const datasetIds: string[] = []
-			const connector = createConnector().stdResourceList(async (_context, input) => {
-				datasetIds.push(input.datasetId)
-			})
-
-			await connector._exec(
-				'std:resource:list',
-				MOCK_CONTEXT,
-				{ datasetIds: ['serviceNow:agent', 'serviceNow:agent', 'other:dataset'] },
-				new PassThrough({ objectMode: true })
-			)
-
-			expect(datasetIds).toEqual(['serviceNow:agent', 'other:dataset'])
-		})
 	})
 
 	it('should execute stdEntitlementListHandler', async () => {

--- a/lib/connector.spec.ts
+++ b/lib/connector.spec.ts
@@ -554,6 +554,22 @@ describe('exec handlers', () => {
 
 			expect(datasetIds).toEqual(['serviceNow:agent'])
 		})
+
+		it('should invoke stdResourceList once per unique datasetId', async () => {
+			const datasetIds: string[] = []
+			const connector = createConnector().stdResourceList(async (_context, input) => {
+				datasetIds.push(input.datasetId)
+			})
+
+			await connector._exec(
+				'std:resource:list',
+				MOCK_CONTEXT,
+				{ datasetIds: ['serviceNow:agent', 'serviceNow:agent', 'other:dataset'] },
+				new PassThrough({ objectMode: true })
+			)
+
+			expect(datasetIds).toEqual(['serviceNow:agent', 'other:dataset'])
+		})
 	})
 
 	it('should execute stdEntitlementListHandler', async () => {

--- a/lib/connector.ts
+++ b/lib/connector.ts
@@ -53,6 +53,8 @@ import {
 	StdMachineIdentityListOutput,
 	StdResourceListInput,
 	StdResourceListOutput,
+	StdResourceListDatasetsInput,
+	StdResourceListDatasetsOutput,
 } from './commands'
 import { RawResponse, ResponseStream, ResponseType, Response, ResponseStreamTransform } from './response'
 import { Transform, TransformCallback, Writable } from 'stream'
@@ -419,6 +421,8 @@ export class Connector {
 
 	/**
 	 * Add a handler for 'std:resource:list' command
+	 * If datasetIds are provided in the input, the handler will be called for each unique datasetId
+	 * If datasetIds are not provided, the standard handler will be called with datasetId
 	 * @param handler handler
 	 */
 	stdResourceList(handler: StdResourceListHandler): this {
@@ -426,20 +430,41 @@ export class Connector {
 			StandardCommand.StdResourceList,
 			async (
 				context: Context,
-				input: StdResourceListInput,
-				res: Response<StdResourceListOutput>
+				input: StdResourceListInput | StdResourceListDatasetsInput,
+				res: Response<StdResourceListDatasetsOutput>
 			): Promise<void> => {
-				const datasetRes = new ResponseStreamTransform<
-					StdResourceListOutput,
-					any
-				>(res, (v: StdResourceListOutput): any => {
-					return {
-						...v,
-						datasetId: input.datasetId,
-					}
-				})
+				const datasetsInput = input as StdResourceListDatasetsInput
+				const singleDatasetInput = input as StdResourceListInput
 
-				await handler(context, input, datasetRes)
+				const buildHandlerInput = (datasetId: string): StdResourceListInput => {
+					const schemas = datasetsInput.resourceSchemas?.[datasetId] ?? datasetsInput.schemas
+
+					return schemas ? { datasetId, schemas } : { datasetId }
+				}
+
+				const invokeHandler = async (datasetId: string): Promise<void> => {
+					const datasetRes = new ResponseStreamTransform<
+						StdResourceListOutput,
+						StdResourceListDatasetsOutput
+					>(res, (v: StdResourceListOutput): StdResourceListDatasetsOutput => {
+						return {
+							...v,
+							datasetId,
+						}
+					})
+
+					await handler(context, buildHandlerInput(datasetId), datasetRes)
+				}
+
+				if (!input || !Array.isArray(datasetsInput.datasetIds) || datasetsInput.datasetIds.length === 0) {
+					const datasetId = singleDatasetInput?.datasetId || ''
+					await invokeHandler(datasetId)
+					return
+				}
+
+				for (const datasetId of uniqueDatasetIds(datasetsInput.datasetIds)) {
+					await invokeHandler(datasetId)
+				}
 			}
 		)
 	}

--- a/lib/connector.ts
+++ b/lib/connector.ts
@@ -53,8 +53,6 @@ import {
 	StdMachineIdentityListOutput,
 	StdResourceListInput,
 	StdResourceListOutput,
-	StdResourceListDatasetsInput,
-	StdResourceListDatasetsOutput,
 } from './commands'
 import { RawResponse, ResponseStream, ResponseType, Response, ResponseStreamTransform } from './response'
 import { Transform, TransformCallback, Writable } from 'stream'
@@ -421,8 +419,6 @@ export class Connector {
 
 	/**
 	 * Add a handler for 'std:resource:list' command
-	 * If datasetIds are provided in the input, the handler will be called for each unique datasetId
-	 * If datasetIds are not provided, the standard handler will be called with datasetId
 	 * @param handler handler
 	 */
 	stdResourceList(handler: StdResourceListHandler): this {
@@ -430,41 +426,20 @@ export class Connector {
 			StandardCommand.StdResourceList,
 			async (
 				context: Context,
-				input: StdResourceListInput | StdResourceListDatasetsInput,
-				res: Response<StdResourceListDatasetsOutput>
+				input: StdResourceListInput,
+				res: Response<StdResourceListOutput>
 			): Promise<void> => {
-				const datasetsInput = input as StdResourceListDatasetsInput
-				const singleDatasetInput = input as StdResourceListInput
+				const datasetRes = new ResponseStreamTransform<
+					StdResourceListOutput,
+					any
+				>(res, (v: StdResourceListOutput): any => {
+					return {
+						...v,
+						datasetId: input.datasetId,
+					}
+				})
 
-				const buildHandlerInput = (datasetId: string): StdResourceListInput => {
-					const schemas = datasetsInput.resourceSchemas?.[datasetId] ?? datasetsInput.schemas
-
-					return schemas ? { datasetId, schemas } : { datasetId }
-				}
-
-				const invokeHandler = async (datasetId: string): Promise<void> => {
-					const datasetRes = new ResponseStreamTransform<
-						StdResourceListOutput,
-						StdResourceListDatasetsOutput
-					>(res, (v: StdResourceListOutput): StdResourceListDatasetsOutput => {
-						return {
-							...v,
-							datasetId,
-						}
-					})
-
-					await handler(context, buildHandlerInput(datasetId), datasetRes)
-				}
-
-				if (!input || !Array.isArray(datasetsInput.datasetIds) || datasetsInput.datasetIds.length === 0) {
-					const datasetId = singleDatasetInput?.datasetId || ''
-					await invokeHandler(datasetId)
-					return
-				}
-
-				for (const datasetId of uniqueDatasetIds(datasetsInput.datasetIds)) {
-					await invokeHandler(datasetId)
-				}
+				await handler(context, input, datasetRes)
 			}
 		)
 	}

--- a/lib/connector.ts
+++ b/lib/connector.ts
@@ -59,6 +59,7 @@ import { Transform, TransformCallback, Writable } from 'stream'
 import { contextState } from './async-context';
 import { ConnectorCustomizer, CustomizerType as CustomizerType } from './connector-customizer'
 import { ConnectorCustomizerHandler } from './connector-customizer-handler'
+import { uniqueDatasetIds } from './dataset-ids'
 
 const SDK_VERSION = 1
 
@@ -188,7 +189,7 @@ export class Connector {
 	/**
 	 * Add a handler for 'std:application-discovery:list' command with dataset context
 	 * @param handler Standard handler for dataset-aware discovery list
-	 * If datasetIds are provided in the input, the datasetHandler will be called for each datasetId
+	 * If datasetIds are provided in the input, the datasetHandler will be called for each unique datasetId
 	 * If datasetIds are not provided, the standard handler will be called
 	 */
 	stdApplicationDiscoveryListWithDataset(handler: StdApplicationDiscoveryDatasetListHandler): this {
@@ -217,7 +218,7 @@ export class Connector {
 					return
 				}
 				// Dataset-aware handling
-				for (const datasetId of input.datasetIds) {
+				for (const datasetId of uniqueDatasetIds(input.datasetIds)) {
 					const datasetRes = new ResponseStreamTransform<
 						StdApplicationDiscoveryListOutput,
 						StdApplicationDiscoveryListDatasetsOutput
@@ -360,7 +361,7 @@ export class Connector {
 				input: StdAgentListDatasetsInput,
 				res: Response<StdAgentListDatasetsOutput>
 			): Promise<void> => {
-				for (const datasetId of input.datasetIds) {
+				for (const datasetId of uniqueDatasetIds(input.datasetIds)) {
 					const datasetRes = new ResponseStreamTransform<StdAgentListOutput, StdAgentListDatasetsOutput>(
 						res,
 						(v: StdAgentListOutput): StdAgentListDatasetsOutput => {
@@ -393,7 +394,7 @@ export class Connector {
 				input: StdMachineIdentityListDatasetsInput,
 				res: Response<StdMachineIdentityListDatasetsOutput>
 			): Promise<void> => {
-				for (const datasetId of input.datasetIds) {
+				for (const datasetId of uniqueDatasetIds(input.datasetIds)) {
 					const datasetRes = new ResponseStreamTransform<
 						StdMachineIdentityListOutput,
 						StdMachineIdentityListDatasetsOutput

--- a/lib/dataset-ids.spec.ts
+++ b/lib/dataset-ids.spec.ts
@@ -1,0 +1,21 @@
+/* Copyright (c) 2026. SailPoint Technologies, Inc. All rights reserved. */
+
+import { uniqueDatasetIds } from './dataset-ids'
+
+describe('uniqueDatasetIds', () => {
+	it('returns unique ids preserving first occurrence order', () => {
+		expect(uniqueDatasetIds(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c'])
+	})
+
+	it('returns a copy when all ids are unique', () => {
+		expect(uniqueDatasetIds(['dataset1', 'dataset2'])).toEqual(['dataset1', 'dataset2'])
+	})
+
+	it('returns empty array for empty input', () => {
+		expect(uniqueDatasetIds([])).toEqual([])
+	})
+
+	it('normalizes ids to strings', () => {
+		expect(uniqueDatasetIds(['1', 1 as unknown as string])).toEqual(['1'])
+	})
+})

--- a/lib/dataset-ids.ts
+++ b/lib/dataset-ids.ts
@@ -1,0 +1,22 @@
+/* Copyright (c) 2026. SailPoint Technologies, Inc. All rights reserved. */
+
+/**
+ * Returns unique dataset IDs while preserving the order of first occurrence.
+ * Connectors may receive duplicate dataset IDs when a spec defines multiple
+ * dataset entries with the same id (for example machine-identity and resource links).
+ */
+export const uniqueDatasetIds = (datasetIds: string[]): string[] => {
+	const seen = new Set<string>()
+	const uniqueIds: string[] = []
+
+	for (const datasetId of datasetIds) {
+		const normalizedId = String(datasetId)
+		if (seen.has(normalizedId)) {
+			continue
+		}
+		seen.add(normalizedId)
+		uniqueIds.push(normalizedId)
+	}
+
+	return uniqueIds
+}


### PR DESCRIPTION
## Summary
- Add `uniqueDatasetIds` utility to deduplicate dataset IDs while preserving first-occurrence order
- Apply deduplication in `stdApplicationDiscoveryListWithDataset`, `stdAgentList`, and `stdMachineIdentityList` command wrappers
- Add unit and integration tests for duplicate dataset ID handling

## Motivation
Connector specs can define multiple dataset entries with the same id (for example machine-identity and resource links). Without SDK-level deduplication, each connector must implement its own workaround to avoid duplicate handler invocations and duplicate records.

## Test plan
- [x] `npm test` — all 201 tests pass
- [x] Verified duplicate `datasetIds` invoke handler once per unique id for application discovery, agent list, and machine identity list


Made with [Cursor](https://cursor.com)